### PR TITLE
Create choice helpers

### DIFF
--- a/hack/ccp/internal/controller/package.go
+++ b/hack/ccp/internal/controller/package.go
@@ -134,14 +134,9 @@ func (p *Package) PreconfiguredChoice(linkID uuid.UUID) (uuid.UUID, error) {
 	}
 
 	var chainID uuid.UUID
-	li := linkID.String()
 	for _, choice := range choices {
-		if choice.AppliesTo == li {
-			if id, err := uuid.Parse(choice.GoToChain); err != nil {
-				return uuid.Nil, err
-			} else {
-				chainID = id
-			}
+		if choice.LinkID() == linkID {
+			chainID = choice.ChainID()
 			break
 		}
 	}
@@ -150,12 +145,8 @@ func (p *Package) PreconfiguredChoice(linkID uuid.UUID) (uuid.UUID, error) {
 	// TODO: allow user to choose the system processing config to use.
 	if chainID == uuid.Nil {
 		for _, choice := range workflow.AutomatedConfig.Choices.Choices {
-			if choice.AppliesTo == li {
-				if id, err := uuid.Parse(choice.GoToChain); err != nil {
-					return uuid.Nil, err
-				} else {
-					chainID = id
-				}
+			if choice.LinkID() == linkID {
+				chainID = choice.ChainID()
 				break
 			}
 		}

--- a/hack/ccp/internal/workflow/config.go
+++ b/hack/ccp/internal/workflow/config.go
@@ -8,6 +8,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/google/uuid"
 )
 
 var builtinConfigs = map[string]ProcessingConfig{
@@ -297,6 +299,24 @@ type Choice struct {
 	Comment   string   `xml:"-"`
 	AppliesTo string   `xml:"appliesTo"`
 	GoToChain string   `xml:"goToChain"`
+}
+
+func (c Choice) LinkID() uuid.UUID {
+	if id, err := uuid.Parse(c.AppliesTo); err != nil {
+		return id
+	}
+	return uuid.Nil
+}
+
+func (c Choice) ChainID() uuid.UUID {
+	if id, err := uuid.Parse(c.GoToChain); err != nil {
+		return id
+	}
+	return uuid.Nil
+}
+
+func (c Choice) Value() string {
+	return c.GoToChain
 }
 
 type Choices struct {


### PR DESCRIPTION
In `processingMCP.xml`, a choice can contain a UUID or a string. This commit provides helpers to consume them without having to deal with parsing elsewhere.