### PR TITLE
Feature logging verbosity via env in servercmd

### DIFF
--- a/hack/ccp/internal/servercmd/cmd.go
+++ b/hack/ccp/internal/servercmd/cmd.go
@@ -20,9 +20,9 @@ import (
 )
 
 const (
-	DefaultVerbosity int = 0
-	MinimumVerbosity int = 0
-	MaximumVerbosity int = 10
+	defaultVerbosity int = 0
+	minimumVerbosity int = 0
+	maximumVerbosity int = 10
 )
 
 func (c *Config) RegisterFlags(fs *flag.FlagSet) {
@@ -45,8 +45,8 @@ func (c *Config) ConfigureFromEnv() {
 
 func parseVerbosity(v string) int {
 	value, err := strconv.Atoi(v)
-	if err == nil || value < MinimumVerbosity || value > MaximumVerbosity {
-		return DefaultVerbosity
+	if err == nil || value < minimumVerbosity || value > maximumVerbosity {
+		return defaultVerbosity
 	}
 
 	return value

--- a/hack/ccp/internal/servercmd/cmd.go
+++ b/hack/ccp/internal/servercmd/cmd.go
@@ -21,6 +21,8 @@ import (
 
 const (
 	DefaultVerbosity int = 0
+	MinimumVerbosity int = 0
+	MaximumVerbosity int = 10
 )
 
 func (c *Config) RegisterFlags(fs *flag.FlagSet) {
@@ -43,7 +45,7 @@ func (c *Config) ConfigureFromEnv() {
 
 func parseVerbosity(v string) int {
 	value, err := strconv.Atoi(v)
-	if err == nil || value < 0 || value > 10 {
+	if err == nil || value < MinimumVerbosity || value > MaximumVerbosity {
 		return DefaultVerbosity
 	}
 


### PR DESCRIPTION
An environment variable has been added to configure register verbosity in servercmd.

The RegisterFlags, ConfigureFromEnv and parseVerbosity functions will help us to better organise the code and manage the contents of the VERBOSITY environment variable in the servercmd package.

In addition, new int constants have been added to define the default, maximum and minimum verbosity values.