### PR TITLE
Add golangci-lint job in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,35 @@ on:
 permissions:
   contents: read
 jobs:
+  golangci-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: hack/ccp/go.mod
+          cache-dependency-path: hack/ccp/go.sum
+      - name: Get date
+        id: get-date
+        shell: bash
+        run: |
+          echo "::set-output name=date::$(date -u "+%Y-%m")"
+      - name: Restore golangci-lint cache
+        uses: actions/cache@v4
+        timeout-minutes: 10
+        continue-on-error: true
+        with:
+          path: ${{ runner.temp }}/golangci-lint-cache
+          key: ${{ runner.os }}-golangci-lint-cache-${{ steps.get-date.outputs.date }}
+          restore-keys: |
+            ${{ runner.os }}-golangci-lint-cache-
+      - name: Run golangci-lint
+        run: make lint
+        env:
+          GOLANGCI_LINT_CACHE: ${{ runner.temp }}/golangci-lint-cache
+        working-directory: hack/ccp
   test:
     name: Test
     strategy:

--- a/hack/ccp/.golangci.yml
+++ b/hack/ccp/.golangci.yml
@@ -8,6 +8,10 @@ linters:
     - gci
     - unparam
     - gosec
+  disable:
+    # There is too much WIP code at the moment.
+    # TODO: enable this ASAP.
+    - unused
 
 issues:
   exclude-dirs:

--- a/hack/ccp/internal/controller/jobs.go
+++ b/hack/ccp/internal/controller/jobs.go
@@ -193,7 +193,7 @@ func (l *outputDecisionJob) exec(ctx context.Context) (uuid.UUID, error) {
 
 	panic("not implemented")
 
-	return uuid.Nil, nil
+	return uuid.Nil, nil // nolint: govet
 }
 
 // nextChainDecisionJob.
@@ -488,7 +488,7 @@ func (l *updateContextDecisionJob) await(ctx context.Context, opts []option) (_ 
 		return uuid.Nil, err
 	}
 
-	decision, err := l.j.pkg.AwaitDecision(ctx, opts)
+	decision, err := l.j.pkg.AwaitDecision(ctx, opts) // nolint: staticcheck
 	if err != nil {
 		return uuid.Nil, err
 	}
@@ -498,7 +498,7 @@ func (l *updateContextDecisionJob) await(ctx context.Context, opts []option) (_ 
 
 	panic("not implemented")
 
-	return decision.uuid(), nil
+	return decision.uuid(), nil // nolint: govet
 }
 
 // directoryClientScriptJob.
@@ -736,7 +736,7 @@ func (l *outputClientScriptJob) exec(ctx context.Context) (uuid.UUID, error) {
 
 	panic("not implemented")
 
-	return uuid.Nil, nil
+	return uuid.Nil, nil // nolint: govet
 }
 
 // setUnitVarLinkJob is a local job that sets the unit variable configured in

--- a/hack/ccp/internal/controller/task.go
+++ b/hack/ccp/internal/controller/task.go
@@ -32,7 +32,7 @@ func newTaskBackend(logger logr.Logger, job *job, config *workflow.LinkStandardT
 	}
 }
 
-func (b *taskBackend) submit(pCtx *packageContext, args string, wantsOutput bool, stdoutFilePath, stderrFilePath string) uuid.UUID {
+func (b *taskBackend) submit(pCtx *packageContext, args string, wantsOutput bool, stdoutFilePath, stderrFilePath string) {
 	t := &task{
 		ID:             uuid.New(),
 		CreatedAt:      time.Now().UTC(),
@@ -47,8 +47,6 @@ func (b *taskBackend) submit(pCtx *packageContext, args string, wantsOutput bool
 	}
 
 	b.tasks.Tasks[t.ID] = t
-
-	return t.ID
 }
 
 func (b *taskBackend) wait(ctx context.Context) (*taskResults, error) {


### PR DESCRIPTION
The unused linter is disabled because I still have too many work-in-progress pieces, but other than that I think this will be useful.