### PR TITLE
Update sqlc-gen-go checksum

### DIFF
--- a/hack/ccp/internal/store/sqlcmysql/models.go
+++ b/hack/ccp/internal/store/sqlcmysql/models.go
@@ -17,8 +17,8 @@ type Access struct {
 	Resource   string
 	Target     string
 	Status     string
-	Statuscode sql.NullInt32
-	Exitcode   sql.NullInt32
+	Statuscode sql.NullInt16
+	Exitcode   sql.NullInt16
 	CreatedAt  time.Time
 	UpdatedAt  time.Time
 }
@@ -542,7 +542,7 @@ type Sip struct {
 	Siptype     string
 	Diruuids    bool
 	CompletedAt sql.NullTime
-	Status      uint32
+	Status      uint16
 }
 
 type SipsIdentifier struct {
@@ -610,7 +610,7 @@ type Transfer struct {
 	Diruuids                   bool
 	AccessSystemID             string
 	CompletedAt                sql.NullTime
-	Status                     uint32
+	Status                     uint16
 }
 
 type Transfermetadatafield struct {

--- a/hack/ccp/sqlc/sqlc.yaml
+++ b/hack/ccp/sqlc/sqlc.yaml
@@ -7,7 +7,7 @@ plugins:
 - name: golang
   wasm:
     url: https://downloads.sqlc.dev/plugin/sqlc-gen-go_1.3.0.wasm
-    sha256: 965d73d22711eee3a210565e66f918b8cb831c5f5b612e680642a4a785dd1ca1
+    sha256: e8206081686f95b461daf91a307e108a761526c6768d6f3eca9781b0726b7ec8
 
 sql:
   - schema: mysql/schema.sql


### PR DESCRIPTION
@repson reported an issue that occured when running `make gen-sqlc`:

```
error generating code: loadModule: invalid checksum: expected 965d73d22711eee3a210565e66f918b8cb831c5f5b612e680642a4a785dd1ca1, got e8206081686f95b461daf91a307e108a761526c6768d6f3eca9781b0726b7ec8
```

That apparently was not a problem in my machine because I had the 1.2.0 version already downloaded with the 965d73d sha256 sum. It sounds like sqlc is not detecting the mismatch because it's not comparing versions? 