### PR TITLE
Implement authn middleware

### DIFF
--- a/hack/ccp/go.mod
+++ b/hack/ccp/go.mod
@@ -4,6 +4,7 @@ go 1.22.5
 
 require (
 	buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.34.1-20240508200655-46a4cf4ba109.1
+	connectrpc.com/authn v0.1.0
 	connectrpc.com/connect v1.16.2
 	connectrpc.com/grpchealth v1.3.0
 	connectrpc.com/grpcreflect v1.2.0

--- a/hack/ccp/go.sum
+++ b/hack/ccp/go.sum
@@ -1,6 +1,8 @@
 buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.34.1-20240508200655-46a4cf4ba109.1 h1:LEXWFH/xZ5oOWrC3oOtHbUyBdzRWMCPpAQmKC9v05mA=
 buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.34.1-20240508200655-46a4cf4ba109.1/go.mod h1:XF+P8+RmfdufmIYpGUC+6bF7S+IlmHDEnCrO3OXaUAQ=
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
+connectrpc.com/authn v0.1.0 h1:m5weACjLWwgwcjttvUDyTPICJKw74+p2obBVrf8hT9E=
+connectrpc.com/authn v0.1.0/go.mod h1:AwNZK/KYbqaJzRYadTuAaoz6sYQSPdORPqh1TOPIkgY=
 connectrpc.com/connect v1.16.2 h1:ybd6y+ls7GOlb7Bh5C8+ghA6SvCBajHwxssO2CGFjqE=
 connectrpc.com/connect v1.16.2/go.mod h1:n2kgwskMHXC+lVqb18wngEpF95ldBHXjZYJussz5FRc=
 connectrpc.com/grpchealth v1.3.0 h1:FA3OIwAvuMokQIXQrY5LbIy8IenftksTP/lG4PbYN+E=

--- a/hack/ccp/internal/api/admin/auth.go
+++ b/hack/ccp/internal/api/admin/auth.go
@@ -1,0 +1,95 @@
+package admin
+
+import (
+	"context"
+	"strings"
+
+	"connectrpc.com/authn"
+	"github.com/go-logr/logr"
+
+	"github.com/artefactual/archivematica/hack/ccp/internal/store"
+)
+
+var errInvalidAuth = authn.Errorf("invalid authorization")
+
+func authenticate(logger logr.Logger, store store.Store) authn.AuthFunc {
+	return multiAuthenticate(
+		authApiKey(logger, store),
+	)
+}
+
+func multiAuthenticate(methods ...authn.AuthFunc) authn.AuthFunc {
+	return func(ctx context.Context, req authn.Request) (any, error) {
+		var lastErr error
+		for _, method := range methods {
+			result, err := method(ctx, req)
+			if err == nil {
+				return result, nil
+			}
+			lastErr = err
+		}
+		return nil, lastErr
+	}
+}
+
+func authApiKey(logger logr.Logger, store store.Store) authn.AuthFunc {
+	return func(ctx context.Context, req authn.Request) (any, error) {
+		auth := req.Header().Get("Authorization")
+		if auth == "" {
+			return nil, errInvalidAuth
+		}
+
+		username, key, ok := parseApiKey(auth)
+		if !ok {
+			return nil, errInvalidAuth
+		}
+
+		ok, err := store.ValidateUserAPIKey(ctx, username, key)
+		if err != nil {
+			logger.Error(err, "Cannot look up user details.")
+			return nil, errInvalidAuth
+		}
+		if !ok {
+			return nil, errInvalidAuth
+		}
+
+		return username, nil
+	}
+}
+
+// parseApiKey parses the ApiKey string.
+// "ApiKey test:test" returns ("test", "test", true).
+func parseApiKey(auth string) (username, key string, ok bool) {
+	const prefix = "ApiKey "
+	// Case insensitive prefix match.
+	if len(auth) < len(prefix) || !equalFold(auth[:len(prefix)], prefix) {
+		return "", "", false
+	}
+	username, key, ok = strings.Cut(auth[len(prefix):], ":")
+	if !ok {
+		return "", "", false
+	}
+	return username, key, true
+}
+
+// equalFold is [strings.EqualFold], ASCII only. It reports whether s and t
+// are equal, ASCII-case-insensitively.
+func equalFold(s, t string) bool {
+	if len(s) != len(t) {
+		return false
+	}
+	for i := range len(s) {
+		if lower(s[i]) != lower(t[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+// lower returns the ASCII lowercase version of b.
+func lower(b byte) byte {
+	if 'A' <= b && b <= 'Z' {
+		return b + ('a' - 'A')
+	}
+	return b
+}

--- a/hack/ccp/internal/api/admin/auth_test.go
+++ b/hack/ccp/internal/api/admin/auth_test.go
@@ -1,0 +1,56 @@
+package admin
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"connectrpc.com/authn"
+	"github.com/artefactual/archivematica/hack/ccp/internal/store/storemock"
+	"github.com/go-logr/logr"
+	"go.artefactual.dev/tools/mockutil"
+	"go.uber.org/mock/gomock"
+	"gotest.tools/v3/assert"
+)
+
+func TestAuthentication(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Accepts API key", func(t *testing.T) {
+		t.Parallel()
+
+		store := storemock.NewMockStore(gomock.NewController(t))
+		store.EXPECT().ValidateUserAPIKey(mockutil.Context(), "test", "test").Return(true, nil)
+
+		auth := multiAuthenticate(authApiKey(logr.Discard(), store))
+		handler := authn.NewMiddleware(auth).Wrap(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+
+		req := httptest.NewRequest("GET", "http://example.com/foo", nil)
+		req.Header.Set("Authorization", "ApiKey test:test")
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+
+		resp := w.Result()
+
+		assert.Equal(t, resp.StatusCode, http.StatusOK)
+	})
+
+	t.Run("Rejects invalid API key", func(t *testing.T) {
+		t.Parallel()
+
+		store := storemock.NewMockStore(gomock.NewController(t))
+		store.EXPECT().ValidateUserAPIKey(mockutil.Context(), "test", "12345").Return(false, nil)
+
+		auth := multiAuthenticate(authApiKey(logr.Discard(), store))
+		handler := authn.NewMiddleware(auth).Wrap(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+
+		req := httptest.NewRequest("GET", "http://example.com/foo", nil)
+		req.Header.Set("Authorization", "ApiKey test:12345")
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+
+		resp := w.Result()
+
+		assert.Equal(t, resp.StatusCode, http.StatusUnauthorized)
+	})
+}

--- a/hack/ccp/internal/store/mysql.go
+++ b/hack/ccp/internal/store/mysql.go
@@ -975,6 +975,20 @@ func (s *mysqlStoreImpl) ReadStorageServiceConfig(ctx context.Context) (ret Stor
 	return ret, nil
 }
 
+func (s *mysqlStoreImpl) ValidateUserAPIKey(ctx context.Context, username, key string) (_ bool, err error) {
+	defer wrap(&err, "ValidateUserAPIKey(%q, %q)", username, key)
+
+	_, err = s.queries.ReadUserWithKey(ctx, &sqlc.ReadUserWithKeyParams{
+		Username: username,
+		Key:      key,
+	})
+	if err == sql.ErrNoRows {
+		return false, nil
+	}
+
+	return true, nil
+}
+
 func (s *mysqlStoreImpl) Running() bool {
 	return s != nil
 }

--- a/hack/ccp/internal/store/sqlcmysql/db.go
+++ b/hack/ccp/internal/store/sqlcmysql/db.go
@@ -96,6 +96,9 @@ func Prepare(ctx context.Context, db DBTX) (*Queries, error) {
 	if q.readUnitVarsStmt, err = db.PrepareContext(ctx, readUnitVars); err != nil {
 		return nil, fmt.Errorf("error preparing query ReadUnitVars: %w", err)
 	}
+	if q.readUserWithKeyStmt, err = db.PrepareContext(ctx, readUserWithKey); err != nil {
+		return nil, fmt.Errorf("error preparing query ReadUserWithKey: %w", err)
+	}
 	if q.updateJobStatusStmt, err = db.PrepareContext(ctx, updateJobStatus); err != nil {
 		return nil, fmt.Errorf("error preparing query UpdateJobStatus: %w", err)
 	}
@@ -239,6 +242,11 @@ func (q *Queries) Close() error {
 			err = fmt.Errorf("error closing readUnitVarsStmt: %w", cerr)
 		}
 	}
+	if q.readUserWithKeyStmt != nil {
+		if cerr := q.readUserWithKeyStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing readUserWithKeyStmt: %w", cerr)
+		}
+	}
 	if q.updateJobStatusStmt != nil {
 		if cerr := q.updateJobStatusStmt.Close(); cerr != nil {
 			err = fmt.Errorf("error closing updateJobStatusStmt: %w", cerr)
@@ -332,6 +340,7 @@ type Queries struct {
 	readTransferWithLocationStmt            *sql.Stmt
 	readUnitVarStmt                         *sql.Stmt
 	readUnitVarsStmt                        *sql.Stmt
+	readUserWithKeyStmt                     *sql.Stmt
 	updateJobStatusStmt                     *sql.Stmt
 	updateSIPLocationStmt                   *sql.Stmt
 	updateSIPStatusStmt                     *sql.Stmt
@@ -368,6 +377,7 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		readTransferWithLocationStmt:            q.readTransferWithLocationStmt,
 		readUnitVarStmt:                         q.readUnitVarStmt,
 		readUnitVarsStmt:                        q.readUnitVarsStmt,
+		readUserWithKeyStmt:                     q.readUserWithKeyStmt,
 		updateJobStatusStmt:                     q.updateJobStatusStmt,
 		updateSIPLocationStmt:                   q.updateSIPLocationStmt,
 		updateSIPStatusStmt:                     q.updateSIPStatusStmt,

--- a/hack/ccp/internal/store/store.go
+++ b/hack/ccp/internal/store/store.go
@@ -115,6 +115,10 @@ type Store interface {
 	// Archivematica Storage Service associated to this pipeline.
 	ReadStorageServiceConfig(ctx context.Context) (StorageServiceConfig, error)
 
+	// ValidateUserAPIKey confirms that the username with the given API key
+	// exists in the database and is active.
+	ValidateUserAPIKey(ctx context.Context, username, key string) (bool, error)
+
 	Running() bool
 	Close() error
 }

--- a/hack/ccp/internal/store/storemock/mock_store.go
+++ b/hack/ccp/internal/store/storemock/mock_store.go
@@ -1206,3 +1206,42 @@ func (c *MockStoreUpsertTransferCall) DoAndReturn(f func(context.Context, uuid.U
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
+
+// ValidateUserAPIKey mocks base method.
+func (m *MockStore) ValidateUserAPIKey(ctx context.Context, username, key string) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ValidateUserAPIKey", ctx, username, key)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ValidateUserAPIKey indicates an expected call of ValidateUserAPIKey.
+func (mr *MockStoreMockRecorder) ValidateUserAPIKey(ctx, username, key any) *MockStoreValidateUserAPIKeyCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidateUserAPIKey", reflect.TypeOf((*MockStore)(nil).ValidateUserAPIKey), ctx, username, key)
+	return &MockStoreValidateUserAPIKeyCall{Call: call}
+}
+
+// MockStoreValidateUserAPIKeyCall wrap *gomock.Call
+type MockStoreValidateUserAPIKeyCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockStoreValidateUserAPIKeyCall) Return(arg0 bool, arg1 error) *MockStoreValidateUserAPIKeyCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockStoreValidateUserAPIKeyCall) Do(f func(context.Context, string, string) (bool, error)) *MockStoreValidateUserAPIKeyCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockStoreValidateUserAPIKeyCall) DoAndReturn(f func(context.Context, string, string) (bool, error)) *MockStoreValidateUserAPIKeyCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}

--- a/hack/ccp/sqlc/mysql/query.sql
+++ b/hack/ccp/sqlc/mysql/query.sql
@@ -161,3 +161,14 @@ SELECT name, value, scope FROM DashboardSettings WHERE name LIKE ?;
 
 -- name: ReadDashboardSetting :one
 SELECT name, value, scope FROM DashboardSettings WHERE name = ?;
+
+--
+-- Authorization
+--
+
+-- name: ReadUserWithKey :one
+SELECT auth_user.id, auth_user.username, auth_user.is_active
+FROM auth_user
+JOIN tastypie_apikey ON auth_user.id = tastypie_apikey.user_id
+WHERE auth_user.username = ? AND tastypie_apikey.key = ? AND auth_user.is_active = 1
+LIMIT 1;

--- a/src/dashboard/src/client/__init__.py
+++ b/src/dashboard/src/client/__init__.py
@@ -12,12 +12,12 @@ from django.utils.translation import get_language
 client_local = threading.local()
 
 
-def get_client(user_id, client_class=None):
+def get_client(user, client_class=None):
     """Return the client for communicating with the MCPServer."""
     if not getattr(client_local, "client", None):
         client_class = client_class or CCPClient
         lang = get_language() or "en"
-        client_local.client = client_class(user_id, lang)
+        client_local.client = client_class(user, lang)
 
     return client_local.client
 

--- a/src/dashboard/src/client/ccp.py
+++ b/src/dashboard/src/client/ccp.py
@@ -121,8 +121,9 @@ class CCPClient(Client):
     supported yet, we choose to make use of the gRPC protocol.
     """
 
-    def __init__(self, user_id, lang):
-        self.user_id = str(user_id)
+    def __init__(self, user, lang):
+        self.username = user.username
+        self.api_key = user.api_key.key
         self.lang = lang
         self.channel = insecure_channel(
             target=settings.GEARMAN_SERVER,
@@ -136,7 +137,7 @@ class CCPClient(Client):
             self.channel,
             header_adder_interceptor(
                 [
-                    ("user_id", self.user_id),
+                    ("authorization", f"apikey {self.username}:{self.api_key}"),
                     ("lang", self.lang),
                 ],
             ),
@@ -145,7 +146,6 @@ class CCPClient(Client):
 
     def _tx(self, translations):
         tx = translations.tx
-
         return tx.get(self.lang, tx.get("en", ""))
 
     def approve_job(self, job_id, choice):

--- a/src/dashboard/src/client/mcp.py
+++ b/src/dashboard/src/client/mcp.py
@@ -69,9 +69,9 @@ INFLIGHT_POLL_TIMEOUT = 30.0
 class MCPClient(Client):
     """Handles communication with MCPServer."""
 
-    def __init__(self, user_id, lang):
+    def __init__(self, user, lang):
         self.server = settings.GEARMAN_SERVER
-        self.user_id = user_id
+        self.user_id = user.id
         self.lang = lang
 
     def _rpc_sync_call(self, ability, data=None, timeout=INFLIGHT_POLL_TIMEOUT):

--- a/src/dashboard/src/components/administration/forms.py
+++ b/src/dashboard/src/components/administration/forms.py
@@ -306,7 +306,7 @@ class ProcessingConfigurationForm(forms.Form):
 
     def load_processing_config_fields(self, user):
         """Obtain processing fields and available choices from MCPServer."""
-        client = get_client(user.id)
+        client = get_client(user)
         self.processing_fields = client.get_processing_config_fields()
 
         # Override labels with translations in this form.

--- a/src/dashboard/src/components/api/views.py
+++ b/src/dashboard/src/components/api/views.py
@@ -510,7 +510,7 @@ def approve_transfer(request):
         # Append a slash to complete the directory path.
         db_transfer_path = os.path.join(watched_path, "")
     try:
-        client = get_client(request.user.id)
+        client = get_client(request.user)
         unit_uuid = client.approve_transfer_by_path(db_transfer_path, transfer_type)
     except Exception as err:
         msg = "Unable to start the transfer."
@@ -547,7 +547,7 @@ def reingest_approve(request):
     if sip_uuid is None:
         return _error_response('"uuid" is required.')
     try:
-        client = get_client(request.user.id)
+        client = get_client(request.user)
         client.approve_partial_reingest(sip_uuid)
     except Exception as err:
         msg = "Unable to approve the partial reingest."
@@ -839,7 +839,7 @@ def _package_create(request):
     if processing_config is not None:
         kwargs["processing_config"] = processing_config
     try:
-        client = get_client(request.user.id)
+        client = get_client(request.user)
         id_ = client.create_package(*args, **kwargs)
     except Exception as err:
         msg = "Package cannot be created"

--- a/src/dashboard/src/components/ingest/views.py
+++ b/src/dashboard/src/components/ingest/views.py
@@ -108,7 +108,7 @@ class SipsView(View):
 def ingest_status(request, uuid=None):
     response = {"objects": {}, "mcp": False}
     try:
-        client = get_client(request.user.id)
+        client = get_client(request.user)
         response["objects"] = client.get_sips_status()
     except Exception:
         pass

--- a/src/dashboard/src/components/ingest/views_as.py
+++ b/src/dashboard/src/components/ingest/views_as.py
@@ -293,7 +293,7 @@ def complete_matching(request, uuid):
     if request.method != "POST":
         return HttpResponse(status=405)
     try:
-        client = get_client(request.user.id)
+        client = get_client(request.user)
         client.execute_package(
             uuid,
             # Microservice: Upload DIP

--- a/src/dashboard/src/components/mcp/views.py
+++ b/src/dashboard/src/components/mcp/views.py
@@ -22,7 +22,7 @@ from lxml import etree
 def execute(request):
     result = ""
     if request.POST.get("uuid"):
-        client = get_client(request.user.id)
+        client = get_client(request.user)
         result = client.approve_job(
             request.POST.get("uuid"), request.POST.get("choice", "")
         )
@@ -30,7 +30,7 @@ def execute(request):
 
 
 def list(request):
-    client = get_client(request.user.id)
+    client = get_client(request.user)
     jobs = etree.XML(client.list_jobs_awaiting_approval())
     response = ""
     if 0 < len(jobs):

--- a/src/dashboard/src/components/transfer/views.py
+++ b/src/dashboard/src/components/transfer/views.py
@@ -124,7 +124,7 @@ def component(request, uuid):
 def status(request, uuid=None):
     response = {"objects": {}, "mcp": False}
     try:
-        client = get_client(request.user.id)
+        client = get_client(request.user)
         response["objects"] = client.get_transfers_status()
     except Exception:
         logger.error("Failed to load packages status.", exc_info=True)

--- a/src/dashboard/src/components/unit/views.py
+++ b/src/dashboard/src/components/unit/views.py
@@ -55,7 +55,7 @@ def microservices(request, unit_type, unit_uuid):
     :param unit_uuid: UUID of the Transfer or SIP
 
     """
-    client = get_client(request.user.id)
+    client = get_client(request.user)
     resp = client.get_package_status(unit_uuid)
     return render(
         request,

--- a/src/dashboard/src/main/management/commands/resolve_pending_jobs.py
+++ b/src/dashboard/src/main/management/commands/resolve_pending_jobs.py
@@ -34,7 +34,7 @@ class Command(DashboardCommand):
         admin_user = self.admin_user()
         if not admin_user:
             raise CommandError("Cannot find a superuser.")
-        client = get_client(admin_user.id)
+        client = get_client(admin_user)
 
         while True:
             self.success("Fetching packages awaiting decisions...")

--- a/src/dashboard/src/main/views.py
+++ b/src/dashboard/src/main/views.py
@@ -74,7 +74,7 @@ def home(request):
 
 # TODO: hide removed elements
 def status(request):
-    client = get_client(request.user.id)
+    client = get_client(request.user)
     xml = etree.XML(client.list_jobs_awaiting_approval())
 
     sip_count = len(


### PR DESCRIPTION
This PR implements an authentication middleware based on [connectrpc.com/authn](https://connectrpc.com/authn). It handles API key authentication using Tastypie's [ApiKeyAuthentication](https://github.com/django-tastypie/django-tastypie/blob/26fcf08f05c9b221727578d548d264c8e0ebba22/tastypie/authentication.py#L202-L284) header scheme for backward compatibility, e.g.:

    grpcui -H "Authorization: ApiKey test:test" -plaintext 127.0.0.1:63030

Fixes https://github.com/artefactual-labs/ccp/issues/61.