### PR TITLE
Save active agent

### DIFF
--- a/hack/ccp/internal/api/admin/admin.go
+++ b/hack/ccp/internal/api/admin/admin.go
@@ -139,7 +139,7 @@ func (s *Server) CreatePackage(ctx context.Context, req *connect.Request[adminv1
 		return nil, connect.NewError(connect.CodeInvalidArgument, err)
 	}
 
-	pkg, err := s.ctrl.Submit(req.Msg)
+	pkg, err := s.ctrl.Submit(ctx, req.Msg)
 	if err != nil {
 		return nil, connect.NewError(connect.CodeUnknown, nil)
 	}
@@ -252,7 +252,7 @@ func (s *Server) ResolveDecision(ctx context.Context, req *connect.Request[admin
 	}
 
 	id := uuid.MustParse(req.Msg.Id)
-	err := s.ctrl.ResolveDecision(id, int(req.Msg.Choice.Id))
+	err := s.ctrl.ResolveDecision(ctx, id, int(req.Msg.Choice.Id))
 	if err != nil {
 		s.logger.Error(err, "Failed to resolve awaiting decision.", "id", id)
 		return nil, connect.NewError(connect.CodeUnknown, nil)

--- a/hack/ccp/internal/api/admin/auth.go
+++ b/hack/ccp/internal/api/admin/auth.go
@@ -44,16 +44,16 @@ func authApiKey(logger logr.Logger, store store.Store) authn.AuthFunc {
 			return nil, errInvalidAuth
 		}
 
-		ok, err := store.ValidateUserAPIKey(ctx, username, key)
+		user, err := store.ValidateUserAPIKey(ctx, username, key)
 		if err != nil {
 			logger.Error(err, "Cannot look up user details.")
 			return nil, errInvalidAuth
 		}
-		if !ok {
+		if user == nil {
 			return nil, errInvalidAuth
 		}
 
-		return username, nil
+		return user, nil
 	}
 }
 

--- a/hack/ccp/internal/api/admin/deprecated.go
+++ b/hack/ccp/internal/api/admin/deprecated.go
@@ -24,7 +24,7 @@ func (s *Server) ApproveJob(ctx context.Context, req *connect.Request[adminv1.Ap
 	}
 
 	jobID := uuid.MustParse(req.Msg.JobId)
-	err := s.ctrl.ResolveDecisionLegacy(jobID, req.Msg.Choice)
+	err := s.ctrl.ResolveDecisionLegacy(ctx, jobID, req.Msg.Choice)
 	if err != nil {
 		s.logger.V(2).Info("Failed to approve job.", "err", err, "jobID", jobID, "choice", req.Msg.Choice)
 		return nil, connect.NewError(connect.CodeUnknown, nil)
@@ -77,7 +77,7 @@ func (s *Server) ApproveTransferByPath(ctx context.Context, req *connect.Request
 		chainID = t.BypassChainID
 	}
 
-	if err := s.ctrl.ResolveDecisionLegacy(jobID, chainID.String()); err != nil {
+	if err := s.ctrl.ResolveDecisionLegacy(ctx, jobID, chainID.String()); err != nil {
 		return nil, connect.NewError(connect.CodeUnknown, fmt.Errorf("unable to resolve decision: %v", err))
 	}
 
@@ -109,7 +109,7 @@ func (s *Server) ApprovePartialReingest(ctx context.Context, req *connect.Reques
 	}
 
 	jobID, _ := uuid.Parse(job.Id)
-	if err := s.ctrl.ResolveDecisionLegacy(jobID, chain.ID.String()); err != nil {
+	if err := s.ctrl.ResolveDecisionLegacy(ctx, jobID, chain.ID.String()); err != nil {
 		return nil, connect.NewError(connect.CodeUnknown, fmt.Errorf("unable to resolve decision: %v", err))
 	}
 

--- a/hack/ccp/internal/controller/package.go
+++ b/hack/ccp/internal/controller/package.go
@@ -8,8 +8,10 @@ import (
 	"maps"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 
+	"connectrpc.com/authn"
 	"github.com/go-logr/logr"
 	"github.com/google/uuid"
 
@@ -148,7 +150,7 @@ func NewTransferPackage(
 		return nil, err
 	}
 
-	if err := pkg.updateActiveAgent(ctx, "TODO"); err != nil {
+	if err := pkg.updateActiveAgent(ctx); err != nil {
 		return nil, err
 	}
 
@@ -368,8 +370,16 @@ func (p *Package) markAsFailed(ctx context.Context) error {
 	return p.store.UpdatePackageStatus(ctx, p.id, p.packageType(), enums.PackageStatusFailed)
 }
 
-func (p *Package) updateActiveAgent(ctx context.Context, userID string) error {
-	return nil // TODO: we have not implemented auth yet!
+// updateActiveAgent saves the activeAgent variable using the user information
+// that is provided in the context.
+func (p *Package) updateActiveAgent(ctx context.Context) error {
+	info := authn.GetInfo(ctx)
+	user, ok := info.(*store.User)
+	if !ok || user == nil || user.AgentID == nil {
+		return nil
+	}
+
+	return p.saveValue(ctx, "activeAgent", strconv.Itoa(*user.AgentID))
 }
 
 // unit represents logic that is specific to a particular type of package, e.g. Transfer.

--- a/hack/ccp/internal/store/sqlcmysql/query.sql.go
+++ b/hack/ccp/internal/store/sqlcmysql/query.sql.go
@@ -619,9 +619,10 @@ func (q *Queries) ReadUnitVars(ctx context.Context, arg *ReadUnitVarsParams) ([]
 
 const readUserWithKey = `-- name: ReadUserWithKey :one
 
-SELECT auth_user.id, auth_user.username, auth_user.is_active
+SELECT auth_user.id, auth_user.username, auth_user.email, auth_user.is_active, main_userprofile.agent_id
 FROM auth_user
 JOIN tastypie_apikey ON auth_user.id = tastypie_apikey.user_id
+LEFT JOIN main_userprofile ON auth_user.id = main_userprofile.user_id
 WHERE auth_user.username = ? AND tastypie_apikey.key = ? AND auth_user.is_active = 1
 LIMIT 1
 `
@@ -634,14 +635,22 @@ type ReadUserWithKeyParams struct {
 type ReadUserWithKeyRow struct {
 	ID       int32
 	Username string
+	Email    string
 	IsActive bool
+	AgentID  sql.NullInt32
 }
 
 // Authorization
 func (q *Queries) ReadUserWithKey(ctx context.Context, arg *ReadUserWithKeyParams) (*ReadUserWithKeyRow, error) {
 	row := q.queryRow(ctx, q.readUserWithKeyStmt, readUserWithKey, arg.Username, arg.Key)
 	var i ReadUserWithKeyRow
-	err := row.Scan(&i.ID, &i.Username, &i.IsActive)
+	err := row.Scan(
+		&i.ID,
+		&i.Username,
+		&i.Email,
+		&i.IsActive,
+		&i.AgentID,
+	)
 	return &i, err
 }
 

--- a/hack/ccp/internal/store/store.go
+++ b/hack/ccp/internal/store/store.go
@@ -115,9 +115,11 @@ type Store interface {
 	// Archivematica Storage Service associated to this pipeline.
 	ReadStorageServiceConfig(ctx context.Context) (StorageServiceConfig, error)
 
-	// ValidateUserAPIKey confirms that the username with the given API key
-	// exists in the database and is active.
-	ValidateUserAPIKey(ctx context.Context, username, key string) (bool, error)
+	// ValidateUserAPIKey checks if a user with the given username and API key
+	// exists and is active. It returns a pointer to the User if valid, or nil
+	// and an error otherwise. A nil User doesn't necessarily mean the user
+	// doesn't exist; check the error for details.
+	ValidateUserAPIKey(ctx context.Context, username, key string) (*User, error)
 
 	Running() bool
 	Close() error
@@ -216,4 +218,12 @@ type FindAwaitingJobParams struct {
 	Directory *string
 	PackageID *uuid.UUID
 	Group     *string
+}
+
+type User struct {
+	ID       int
+	Username string
+	Email    string
+	Active   bool
+	AgentID  *int
 }

--- a/hack/ccp/internal/store/storemock/mock_store.go
+++ b/hack/ccp/internal/store/storemock/mock_store.go
@@ -1208,10 +1208,10 @@ func (c *MockStoreUpsertTransferCall) DoAndReturn(f func(context.Context, uuid.U
 }
 
 // ValidateUserAPIKey mocks base method.
-func (m *MockStore) ValidateUserAPIKey(ctx context.Context, username, key string) (bool, error) {
+func (m *MockStore) ValidateUserAPIKey(ctx context.Context, username, key string) (*store.User, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ValidateUserAPIKey", ctx, username, key)
-	ret0, _ := ret[0].(bool)
+	ret0, _ := ret[0].(*store.User)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -1229,19 +1229,19 @@ type MockStoreValidateUserAPIKeyCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockStoreValidateUserAPIKeyCall) Return(arg0 bool, arg1 error) *MockStoreValidateUserAPIKeyCall {
+func (c *MockStoreValidateUserAPIKeyCall) Return(arg0 *store.User, arg1 error) *MockStoreValidateUserAPIKeyCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStoreValidateUserAPIKeyCall) Do(f func(context.Context, string, string) (bool, error)) *MockStoreValidateUserAPIKeyCall {
+func (c *MockStoreValidateUserAPIKeyCall) Do(f func(context.Context, string, string) (*store.User, error)) *MockStoreValidateUserAPIKeyCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStoreValidateUserAPIKeyCall) DoAndReturn(f func(context.Context, string, string) (bool, error)) *MockStoreValidateUserAPIKeyCall {
+func (c *MockStoreValidateUserAPIKeyCall) DoAndReturn(f func(context.Context, string, string) (*store.User, error)) *MockStoreValidateUserAPIKeyCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/hack/ccp/sqlc/mysql/query.sql
+++ b/hack/ccp/sqlc/mysql/query.sql
@@ -167,8 +167,9 @@ SELECT name, value, scope FROM DashboardSettings WHERE name = ?;
 --
 
 -- name: ReadUserWithKey :one
-SELECT auth_user.id, auth_user.username, auth_user.is_active
+SELECT auth_user.id, auth_user.username, auth_user.email, auth_user.is_active, main_userprofile.agent_id
 FROM auth_user
 JOIN tastypie_apikey ON auth_user.id = tastypie_apikey.user_id
+LEFT JOIN main_userprofile ON auth_user.id = main_userprofile.user_id
 WHERE auth_user.username = ? AND tastypie_apikey.key = ? AND auth_user.is_active = 1
 LIMIT 1;


### PR DESCRIPTION
Use the info details provided by authn to save the active agent when a transfer is created or a decision is resolved.